### PR TITLE
Add StreetNetwork node location from name

### DIFF
--- a/src/main/java/org/commitment_issues/delivery_agents/StreetNetworkAgent.java
+++ b/src/main/java/org/commitment_issues/delivery_agents/StreetNetworkAgent.java
@@ -315,6 +315,24 @@ public class StreetNetworkAgent extends BaseAgent {
 		return nodeID;
 	}
 	
+	protected JSONObject findLocationFromNode(String queryID) {
+		JSONObject nodeLocation = new JSONObject();
+		
+		int numNodes = nodesJSONArray.length();
+		
+		for (int i = 0; i < numNodes; i++) {
+			JSONObject nodeInfo = nodesJSONArray.getJSONObject(i);
+			
+			String nodeID = nodeInfo.getString("guid");
+			
+			if (nodeID.equals(queryID)) {
+				nodeLocation = nodeInfo.getJSONObject("location");
+			}
+		}
+		
+		return nodeLocation;
+	}
+	
 	protected double getPathTime(LinkedList<Vertex> fullPath) {
 		double time = 0.0;
 		double speedFactor = 1.0;

--- a/src/main/java/org/commitment_issues/delivery_agents/StreetNetworkAgent.java
+++ b/src/main/java/org/commitment_issues/delivery_agents/StreetNetworkAgent.java
@@ -38,6 +38,7 @@ public class StreetNetworkAgent extends BaseAgent {
 //		addBehaviour(new GraphVisualizerServer());
 		addBehaviour(new TimeToDeliveryServer());
 		addBehaviour(new PathServer());
+		addBehaviour(new NodeLocationServer());
 		addBehaviour(new TimeUpdater());
 	}
 	  
@@ -349,19 +350,23 @@ public class StreetNetworkAgent extends BaseAgent {
 	
 	protected String findLocationFromNode(String queryID) {
 		JSONObject nodeLocation = new JSONObject();
+		String nodeID = null;
 		
 		int numNodes = nodesJSONArray.length();
 		
 		for (int i = 0; i < numNodes; i++) {
 			JSONObject nodeInfo = nodesJSONArray.getJSONObject(i);
 			
-			String nodeID = nodeInfo.getString("guid");
+			try {
+				nodeID = nodeInfo.getString("company");
+			} catch (Exception e) {
+				continue;
+			}
 			
 			if (nodeID.equals(queryID)) {
 				nodeLocation = nodeInfo.getJSONObject("location");
 			}
 		}
-		
 		return nodeLocation.toString();
 	}
 	

--- a/src/main/java/org/commitment_issues/delivery_agents/StreetNetworkAgent.java
+++ b/src/main/java/org/commitment_issues/delivery_agents/StreetNetworkAgent.java
@@ -171,6 +171,40 @@ public class StreetNetworkAgent extends BaseAgent {
 		}
 	}
 	
+	private class NodeLocationServer extends CyclicBehaviour {
+		private MessageTemplate mt;
+
+		public void action() {
+			mt = MessageTemplate.and(MessageTemplate.MatchConversationId("LocationQuery"),
+					MessageTemplate.MatchPerformative(ACLMessage.REQUEST));
+			ACLMessage msg = myAgent.receive(mt);
+								
+			
+			if (msg != null) {
+				// DEBUG:
+				System.out.println("["+getAID().getLocalName()+"]: Received node location request from "+msg.getSender().getLocalName());
+				
+				String truckNodeQuery = msg.getContent();
+				ACLMessage reply = msg.createReply();
+				
+				String JSONNodeLocation = findLocationFromNode(truckNodeQuery);
+
+
+				reply.setPerformative(ACLMessage.INFORM);
+				reply.setContent(String.valueOf(JSONNodeLocation));
+				myAgent.send(reply);
+				
+				// DEBUG:
+				System.out.println("["+getAID().getLocalName()+"]: Returned queried node location coordinates for "+msg.getSender().getLocalName()+" is "+time);
+				
+			}
+
+			else {
+				block();
+			}
+		}
+	}
+	
 	protected String createVisualizerMessage() {
 		JSONObject JSONVisData = new JSONObject();
 		JSONArray JSONVisNodes = new JSONArray();

--- a/src/main/java/org/commitment_issues/delivery_agents/StreetNetworkAgent.java
+++ b/src/main/java/org/commitment_issues/delivery_agents/StreetNetworkAgent.java
@@ -195,10 +195,8 @@ public class StreetNetworkAgent extends BaseAgent {
 				myAgent.send(reply);
 				
 				// DEBUG:
-				System.out.println("["+getAID().getLocalName()+"]: Returned queried node location coordinates for "+msg.getSender().getLocalName()+" is "+time);
-				
+				System.out.println("["+getAID().getLocalName()+"]: Returned queried node location coordinates for "+msg.getSender().getLocalName()+" are "+JSONNodeLocation);
 			}
-
 			else {
 				block();
 			}
@@ -349,7 +347,7 @@ public class StreetNetworkAgent extends BaseAgent {
 		return nodeID;
 	}
 	
-	protected JSONObject findLocationFromNode(String queryID) {
+	protected String findLocationFromNode(String queryID) {
 		JSONObject nodeLocation = new JSONObject();
 		
 		int numNodes = nodesJSONArray.length();
@@ -364,7 +362,7 @@ public class StreetNetworkAgent extends BaseAgent {
 			}
 		}
 		
-		return nodeLocation;
+		return nodeLocation.toString();
 	}
 	
 	protected double getPathTime(LinkedList<Vertex> fullPath) {


### PR DESCRIPTION
This adds the functionality that allows querying the street network agent for a particular node's location, and subsequently receiving its location coordinates.